### PR TITLE
add data-url canonicalization before hashing for json mime-type

### DIFF
--- a/iscc_core/code_meta.py
+++ b/iscc_core/code_meta.py
@@ -4,6 +4,7 @@ from more_itertools import interleave, sliced
 from blake3 import blake3
 from typing import Optional, Union
 from data_url import DataURL
+from ast import literal_eval
 import iscc_core as ic
 
 
@@ -65,6 +66,10 @@ def gen_meta_code_v0(name, description=None, meta=None, bits=ic.core_opts.meta_b
             # Data-URL expected
             durl = meta
             payload = DataURL.from_url(durl).data
+            durl_mime_type = DataURL.from_url(durl).mime_type
+            if "json" in durl_mime_type:
+                durl_data_eval = literal_eval(payload.decode('utf-8'))
+                payload = jcs.canonicalize(durl_data_eval)
             meta_code_digest = soft_hash_meta_v0(name, payload)
             metahash = ic.multi_hash_blake3(payload)
             metadata_value = durl

--- a/iscc_core/data.json
+++ b/iscc_core/data.json
@@ -214,10 +214,10 @@
         64
       ],
       "outputs": {
-        "iscc": "ISCC:AAAWKLHFXN43ICP2",
+        "iscc": "ISCC:AAAWKLHFXN63LHL2",
         "name": "Hello",
         "meta": "data:application/json;charset=utf-8;base64,eyJzb21lIjogIm9iamVjdCJ9",
-        "metahash": "1e20796fdfd4ba8db1a63a1ad1377fa735cad99a10ff08bc655a7095d6508e815a0f"
+        "metahash": "1e20111d3302b0605ec558c390ee013ae89ec6eea68ad2317a8b2de3f4169afeb2ca"
       }
     }
   },


### PR DESCRIPTION
As explained in this [issue](https://github.com/branciard/iscc-core-ts/issues/2), if we always must canonicalize before hashing, here a pull request proposal to add this extra canonicalization step in case of JSON mime type.

Or maybe we should consider that the input test must be  : 
`'data:application/json;charset=utf-8;base64,eyJzb21lIjoib2JqZWN0In0='`
instead of 
`'data:application/json;charset=utf-8;base64,eyJzb21lIjogIm9iamVjdCJ9'` ?
knowing that : 
- base64 of `{"some": "object"} `is equal `eyJzb21lIjogIm9iamVjdCJ9`
- base64 of `{"some":"object"}` equal `eyJzb21lIjoib2JqZWN0In0=`

In this pull request both urls above will generate the same ISCC and metahash
